### PR TITLE
PayNSpray Refuel Setting

### DIFF
--- a/Los Santos RED/lsr/Data/Settings/PlayerGeneralSettings/VehicleSettings.cs
+++ b/Los Santos RED/lsr/Data/Settings/PlayerGeneralSettings/VehicleSettings.cs
@@ -83,6 +83,8 @@ public class VehicleSettings : ISettingsDefaultable
     public bool NonRoadworthyVehicleCheckNoHeadlights { get; set; }
     [Description("If enabled, not having a license plate will mark the vehicle as non-roadworthy.")]
     public bool NonRoadworthyVehicleCheckNoPlate { get; set; }
+    [Description("If enabled, vehicles will be refuelled when repairing at Pay n Spray.")]
+    public bool RefuelVehicleAfterPayNSprayRepair { get; set; }
     public bool AttachOwnedVehicleBlips { get; set; }
 
 
@@ -143,6 +145,7 @@ public class VehicleSettings : ISettingsDefaultable
         NonRoadworthyVehicleCheckDamagedTires = true;
         NonRoadworthyVehicleCheckNoHeadlights = true;
         NonRoadworthyVehicleCheckNoPlate = true;
+        RefuelVehicleAfterPayNSprayRepair = true;
         AttachOwnedVehicleBlips = true;
         PlayControlAnimations = true;
         AutoHotwire = false;

--- a/Los Santos RED/lsr/Locations/Places/GameLocations/PayNSpray/RepairGarage.cs
+++ b/Los Santos RED/lsr/Locations/Places/GameLocations/PayNSpray/RepairGarage.cs
@@ -266,9 +266,22 @@ public class RepairGarage : GameLocation
         {
             return;
         }
+
+        float OldFuel = Player.CurrentVehicle.Vehicle.FuelLevel;
+
         Player.CurrentVehicle.Vehicle.Repair();
         Player.CurrentVehicle.Vehicle.Wash();
-        Player.CurrentVehicle.Vehicle.FuelLevel = Settings.SettingsManager.VehicleSettings.CustomFuelSystemFuelMax;
+
+        if (Settings.SettingsManager.VehicleSettings.RefuelVehicleAfterPayNSprayRepair)
+        {
+            Player.CurrentVehicle.Vehicle.FuelLevel = Settings.SettingsManager.VehicleSettings.CustomFuelSystemFuelMax;
+        }
+        else
+        {
+            Player.CurrentVehicle.Vehicle.FuelLevel = OldFuel;
+        }
+
+
 
     }
     private void RemoveWanted()


### PR DESCRIPTION
Added a setting that determines whether or not to refuel vehicles when they are repaired at a Pay N Spray.