### PR TITLE
ShowRadarWhenCellPhoneActiveOnly - UI Setting

### DIFF
--- a/Los Santos RED/lsr/Data/Settings/UI settings/UIGeneralSettings.cs
+++ b/Los Santos RED/lsr/Data/Settings/UI settings/UIGeneralSettings.cs
@@ -14,6 +14,7 @@ public class UIGeneralSettings : ISettingsDefaultable
     public bool AlwaysShowRadar { get; set; }
     public bool NeverShowRadar { get; set; }
     public bool ShowRadarInVehicleOnly { get; set; }
+    public bool ShowRadarWhenCellPhoneActiveOnly { get; set; }
     public bool ShowRadarOnFootWhenCellPhoneActiveOnly { get; set; }
     public bool HideLSRUIUnlessActionWheelActive { get; set; }
     public bool HideRadarUnlessActionWheelActive { get; set; }
@@ -98,6 +99,7 @@ public class UIGeneralSettings : ISettingsDefaultable
         AlwaysShowRadar = true;
         NeverShowRadar = false;
         ShowRadarInVehicleOnly = false;
+        ShowRadarWhenCellPhoneActiveOnly = false;
         ShowRadarOnFootWhenCellPhoneActiveOnly = false;
         HideLSRUIUnlessActionWheelActive = false;
         HideRadarUnlessActionWheelActive = false;

--- a/Los Santos RED/lsr/UI/UI.cs
+++ b/Los Santos RED/lsr/UI/UI.cs
@@ -403,10 +403,32 @@ public class UI : IMenuProvideable
                     ShowRadar = false;
                 }
             }
+            else if (Settings.SettingsManager.UIGeneralSettings.ShowRadarWhenCellPhoneActiveOnly)
+            {
+                if (DisplayablePlayer.CellPhone.IsActive)
+                {
+                    ShowRadar = true;
+                }
+                else
+                {
+                    ShowRadar = false;
+                }
+            }
         }
         else if (!DisplayablePlayer.IsInVehicle)
         {
             if (Settings.SettingsManager.UIGeneralSettings.ShowRadarOnFootWhenCellPhoneActiveOnly)
+            {
+                if (DisplayablePlayer.CellPhone.IsActive)
+                {
+                    ShowRadar = true;
+                }
+                else
+                {
+                    ShowRadar = false;
+                }
+            }
+            else if (Settings.SettingsManager.UIGeneralSettings.ShowRadarWhenCellPhoneActiveOnly)
             {
                 if (DisplayablePlayer.CellPhone.IsActive)
                 {


### PR DESCRIPTION
Added a setting that allows players to display the minimap whenever the phone is displayed. An alternative to the OnFoot option already included.

Created to mimic real life navigation, looking at phone to use GPS.