### PR TITLE
Modifying Drinking Activity

### DIFF
--- a/Los Santos RED/lsr/Data/Settings/PlayerGeneralSettings/ActivitySettings.cs
+++ b/Los Santos RED/lsr/Data/Settings/PlayerGeneralSettings/ActivitySettings.cs
@@ -51,7 +51,7 @@ public class ActivitySettings : ISettingsDefaultable
     public uint DrinkTimeBetween { get; set; }
     [Description("Does the base animation play when drinking")]
     public bool DrinkStartsBase { get; set; }
-
+    public uint DrinkSipsAllowed { get; set; }
     public float BlendInIdleDrink { get; set; }
     public float BlendOutIdleDrink { get; set; }
     public float BlendInBaseDrink { get; set; }
@@ -131,6 +131,7 @@ public class ActivitySettings : ISettingsDefaultable
         PlateTheftFloat = 1.0f;
         DrinkTimeBetween = 0;
         DrinkStartsBase = false;
+        DrinkSipsAllowed = 5;
         DisplayBodyArmor = false;
         BodyArmorDefaultDrawableID = 11;
         BodyArmorDefaultTextureID = 1;


### PR DESCRIPTION
- Bought back chugging your drink, a feature that was recently removed.
- Added a new feature where players can sip a custom amount and modify that value through ActivitySettings.

1. Variables are a bit gross, but it'll do I guess.
2. Players could be allowed to modify keybinds for Drinking, but I don't want to change too much.
