### PR TITLE
Added BitesAllowed & FinishMeal, Fixed Drinking Bug

### DIFF
--- a/Los Santos RED/lsr/Data/Settings/PlayerGeneralSettings/ActivitySettings.cs
+++ b/Los Santos RED/lsr/Data/Settings/PlayerGeneralSettings/ActivitySettings.cs
@@ -57,6 +57,8 @@ public class ActivitySettings : ISettingsDefaultable
     public float BlendInBaseDrink { get; set; }
     public float BlendOutBaseDrink { get; set; }
     public float DrinkAnimBaseEndingPercentage { get; set; }
+    public uint BitesAllowed { get; set; }
+    [Description("Bite X amount of times")]
 
 
 
@@ -162,6 +164,7 @@ public class ActivitySettings : ISettingsDefaultable
         BlendOutBaseDrink = 1.0f;
 
         DrinkAnimBaseEndingPercentage = 0.7f;
+        BitesAllowed = 5;
 
 
 

--- a/Los Santos RED/lsr/Player/Activity/Items/DrinkingActivityNew.cs
+++ b/Los Santos RED/lsr/Player/Activity/Items/DrinkingActivityNew.cs
@@ -135,7 +135,7 @@ namespace LosSantosRED.lsr.Player
                     {
                         IsCancelled = true;
                     }
-                    if (comboSip > 0 && comboSip != DrinkSipsAllowed)
+                    else if (comboSip > 0 && comboSip != DrinkSipsAllowed)
                     {
                         ConsumableItemNeedGain.Update();
                         TimesDrank++;
@@ -147,7 +147,7 @@ namespace LosSantosRED.lsr.Player
                         IsFinishedWithSip = false;
                         Player.ButtonPrompts.RemovePrompts("DrinkingActivity");
                     }
-                    if (FinishDrink && TimesDrank < DrinkItem.AnimationCycles)
+                    else if (FinishDrink && TimesDrank < DrinkItem.AnimationCycles)
                     {
                         ConsumableItemNeedGain.Update();
                         TimesDrank++;


### PR DESCRIPTION
1. Added BitesAllowed setting to ActivitySettings.xml (default. 5)
2. Fixed Drinking Bug. Character now stops drinking after finishing AnimCycles & ItemNeedGain. Applied same logic for Eating.
3. Added "take x amount of bites" & "finish meal"