### PR TITLE
Riddle me this

### DIFF
--- a/Los Santos RED/lsr/UI/UI.cs
+++ b/Los Santos RED/lsr/UI/UI.cs
@@ -355,7 +355,7 @@ public class UI : IMenuProvideable
 
             if(StartedBustedEffect || StartedDeathEffect)
             {
-                BigMessage.Fiber?.Abort();
+                BigMessage?.Fiber?.Abort();
                 EntryPoint.WriteToConsole("REMOVE FIBER RAN!");
             }
             StartedBustedEffect = false;


### PR DESCRIPTION
When ped-swapping, player has ScreenEffectsUpdate error. Just added the null conditional operator

Error: Object reference not set to an instance of an object. :    at UI.ScreenEffectsUpdate() in C:\Users\trunger\source\repos\thatoneguy650\Los-Santos-RED\Los Santos RED\lsr\UI\UI.cs:line 358
[8/3/2024 11:39:52.409]    at UI.Tick3() in C:\Users\trunger\source\repos\thatoneguy650\Los-Santos-RED\Los Santos RED\lsr\UI\UI.cs:line 168
[8/3/2024 11:39:52.409]    at LosSantosRED.lsr.ModController.<StartUILogic>b__60_2() in C:\Users\trunger\source\repos\thatoneguy650\Los-Santos-RED\Los Santos RED\ModController.cs:line 373