### PR TITLE
Zoned Out

### DIFF
--- a/Los Santos RED/Los Santos RED.csproj
+++ b/Los Santos RED/Los Santos RED.csproj
@@ -662,6 +662,7 @@
     <Compile Include="lsr\UI\Other\VehicleShowcase.cs" />
     <Compile Include="lsr\UI\Pause Menu\Tabs\ContactsAddTab.cs" />
     <Compile Include="lsr\UI\Pause Menu\Tabs\ITabbableMenu.cs" />
+    <Compile Include="lsr\UI\Pause Menu\Tabs\ZonesTab.cs" />
     <Compile Include="lsr\UI\Pop Up Menu\DrawableIcon.cs" />
     <Compile Include="lsr\UI\Stree Name Pop Ups\StreetNamePopUp.cs" />
     <Compile Include="lsr\UI\Stree Name Pop Ups\StreetNode.cs" />

--- a/Los Santos RED/lsr/UI/Pause Menu/PlayerInfoMenu.cs
+++ b/Los Santos RED/lsr/UI/Pause Menu/PlayerInfoMenu.cs
@@ -73,7 +73,7 @@ public class PlayerInfoMenu
         LicensesTab = new LicensesTab(Player, Time, tabView, LocationTypes);
         CrimesTab = new CrimesTab(Player, tabView);
         GangTab = new GangTab(Player,PlacesOfInterest,ShopMenus,ModItems,Weapons,GangTerritories,Zones, tabView, Time, Settings, World);
-        ZonesTab = new ZonesTab(Zones, tabView);
+        ZonesTab = new ZonesTab(Player, PlacesOfInterest, ShopMenus, ModItems, Zones, tabView, GangTerritories, Settings, World);
     }
     public void Toggle()
     {

--- a/Los Santos RED/lsr/UI/Pause Menu/PlayerInfoMenu.cs
+++ b/Los Santos RED/lsr/UI/Pause Menu/PlayerInfoMenu.cs
@@ -32,6 +32,7 @@ public class PlayerInfoMenu
     private LicensesTab LicensesTab;
     private CrimesTab CrimesTab;
     private GangTab GangTab;
+    private ZonesTab ZonesTab;
 
     private ISettingsProvideable Settings;
     private ILocationTypes LocationTypes;
@@ -72,6 +73,7 @@ public class PlayerInfoMenu
         LicensesTab = new LicensesTab(Player, Time, tabView, LocationTypes);
         CrimesTab = new CrimesTab(Player, tabView);
         GangTab = new GangTab(Player,PlacesOfInterest,ShopMenus,ModItems,Weapons,GangTerritories,Zones, tabView, Time, Settings, World);
+        ZonesTab = new ZonesTab(Zones, tabView);
     }
     public void Toggle()
     {
@@ -117,6 +119,7 @@ public class PlayerInfoMenu
         LicensesTab.AddItems();
         CrimesTab.AddItems();
         GangTab.AddItems();
+        ZonesTab.AddItems();
         LocationsTab.AddItems();
 
         tabView.RefreshIndex();

--- a/Los Santos RED/lsr/UI/Pause Menu/Tabs/ZonesTab.cs
+++ b/Los Santos RED/lsr/UI/Pause Menu/Tabs/ZonesTab.cs
@@ -1,0 +1,42 @@
+﻿using LosSantosRED.lsr.Interface;
+using Rage;
+using RAGENativeUI.PauseMenu;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+
+public class ZonesTab
+{
+    private IZones Zones;
+
+    private TabView TabView;
+    private List<TabItem> items;
+    private bool addedItems;
+
+    public ZonesTab(IZones zones, TabView tabView)
+    {
+        Zones = zones;
+        TabView = tabView;
+    }
+    public void AddItems()
+    {
+        items = new List<TabItem>();
+        addedItems = false;
+        foreach (Zone zone in Zones.ZoneList.OrderBy(x => x.DisplayName))
+        {
+            AddItem(zone);
+        }
+        if (addedItems)
+        {
+            TabView.AddTab(new TabSubmenuItem("Zones", items));
+        }
+    }
+    private void AddItem(Zone zone)
+    {
+        items.Add(new TabItem(zone.DisplayName));
+        addedItems = true;
+    }
+}

--- a/Los Santos RED/lsr/UI/Pause Menu/Tabs/ZonesTab.cs
+++ b/Los Santos RED/lsr/UI/Pause Menu/Tabs/ZonesTab.cs
@@ -1,4 +1,5 @@
 ﻿using LosSantosRED.lsr.Interface;
+using Mod;
 using Rage;
 using RAGENativeUI.PauseMenu;
 using System;
@@ -6,26 +7,41 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
+using static DispatchScannerFiles;
 
 public class ZonesTab
 {
+    private IGangRelateable Player;
+    private IPlacesOfInterest PlacesOfInterest;
+    private IShopMenus ShopMenus;
+    private IModItems ModItems;
+    private IGangTerritories GangTerritories;
     private IZones Zones;
+    private ISettingsProvideable Settings;
 
     private TabView TabView;
     private List<TabItem> items;
     private bool addedItems;
+    private IEntityProvideable World;
 
-    public ZonesTab(IZones zones, TabView tabView)
+    public ZonesTab(IGangRelateable player, IPlacesOfInterest placesOfInterest, IShopMenus shopMenus, IModItems modItems, IZones zones, TabView tabView, IGangTerritories gangTerritories, ISettingsProvideable settings, IEntityProvideable world)
     {
+        Player = player;
+        PlacesOfInterest = placesOfInterest;
+        ShopMenus = shopMenus;
+        ModItems = modItems;
         Zones = zones;
         TabView = tabView;
+        GangTerritories = gangTerritories;
+        Settings = settings;
+        World = world;
     }
     public void AddItems()
     {
         items = new List<TabItem>();
         addedItems = false;
-        foreach (Zone zone in Zones.ZoneList.OrderBy(x => x.DisplayName))
+        string currentState = Player.CurrentLocation.CurrentZone?.GameState?.StateID;
+        foreach (Zone zone in Zones.ZoneList.Where(x => x.GameState?.StateID == currentState).OrderBy(x => x.DisplayName))
         {
             AddItem(zone);
         }
@@ -36,7 +52,117 @@ public class ZonesTab
     }
     private void AddItem(Zone zone)
     {
-        items.Add(new TabItem(zone.DisplayName));
+        List<MissionInformation> zoneMissionInfos = new List<MissionInformation>();
+        // Relationship *planned*
+        // infamy etc etc like watch dogs
+
+        // gangs
+        List<Tuple<string, string>> gangTuples = AddGangs(zone);
+        MissionInformation GangInformation = new MissionInformation("Gangs", "", gangTuples);
+        zoneMissionInfos.Add(GangInformation);
+        // police
+
+        // drugs
+        List<Tuple<string, string>> drugTuples = AddDrugs(zone);
+        MissionInformation DrugInformation = new MissionInformation("Drugs", "", drugTuples);
+        zoneMissionInfos.Add(DrugInformation);
+
+        TabMissionSelectItem ZoneList = new TabMissionSelectItem($"{zone.DisplayName}~s~", zoneMissionInfos);
+        items.Add(ZoneList);
         addedItems = true;
     }
+
+    private List<Tuple<string, string>> AddGangs(Zone zone)
+    {
+        List<Tuple<string, string>> toReturn = new List<Tuple<string, string>>();
+        foreach (GangReputation gr in Player.RelationshipManager.GangRelationships.GangReputations.OrderByDescending(x => x.GangRelationship == GangRespect.Member).ThenByDescending(x => x.GangRelationship == GangRespect.Hostile).ThenByDescending(x => x.GangRelationship == GangRespect.Friendly).ThenByDescending(x => Math.Abs(x.ReputationLevel)).ThenBy(x => x.Gang.ShortName))
+        {
+            List<ZoneJurisdiction> gangTerritory = GangTerritories.GetGangTerritory(gr.Gang.ID);
+
+            if (gangTerritory != null && gangTerritory.Any())
+            {
+                foreach (ZoneJurisdiction zj in gangTerritory)
+                {
+                    Zone gangZone = Zones.GetZone(zj.ZoneInternalGameName);
+                    if (gangZone != null && gangZone == zone)
+                    {
+                        toReturn.Add(new Tuple<string, string>($"{gr.Gang.ShortName} {gr.ToBlip()}", "")); break;
+                    }
+                }
+            }
+        }
+        return toReturn;
+    }
+    private List<Tuple<string, string>> AddDrugs(Zone zone)
+    {
+        List<Tuple<string, string>> toReturn = new List<Tuple<string, string>>();
+        List<ModItem> drugsList = ModItems.AllItems().Where(x => x.ItemType == ItemType.Drugs && x.ItemSubType == ItemSubType.Narcotic).ToList();
+        List<string> zoneDrugs = new List<string>();
+
+        // Get economy drug menu. Unsure how to do this.
+
+        if (GangTerritories.GetGangs(zone.InternalGameName, 0) != null)
+        {
+            List<Gang> gangList = GangTerritories.GetGangs(zone.InternalGameName, 0);
+            foreach (Gang gang in gangList)
+            {
+                GangDen myDen = PlacesOfInterest.GetMainDen(gang.ID, World.IsMPMapLoaded);
+                ShopMenu dealerMenu;
+                ShopMenu denMenu;
+                dealerMenu = ShopMenus.GetWeightedRandomMenuFromGroup(gang.DealerMenuGroup);
+                denMenu = myDen?.Menu;
+
+                if (dealerMenu != null)
+                {
+                    foreach (MenuItem mi in dealerMenu.Items)
+                    {
+                        ModItem modItem = ModItems.Get(mi.ModItemName);
+                        if (modItem != null)
+                        {
+                            if (modItem.ItemType == ItemType.Drugs && !zoneDrugs.Contains(modItem.Name))
+                            {
+                                zoneDrugs.Add(modItem.Name);
+                            }
+                        }
+                    }
+                }
+                if (denMenu != null)
+                {
+                    foreach (MenuItem mi in denMenu.Items)
+                    {
+                        ModItem modItem = ModItems.Get(mi.ModItemName);
+                        if (modItem != null)
+                        {
+                            if (modItem.ItemType == ItemType.Drugs && !zoneDrugs.Contains(modItem.Name))
+                            {
+                                zoneDrugs.Add(modItem.Name);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (zone.CustomerMenus != null)
+        {
+            foreach (ModItem drug in drugsList)
+            {
+                if (zone.CustomerMenus.HasItem(drug, ShopMenus) && !zoneDrugs.Contains(drug.Name))
+                {
+                    zoneDrugs.Add(drug.Name);
+                }
+            }
+        }
+
+        if (zoneDrugs.Any())
+        {
+            foreach (string drug in zoneDrugs)
+            {
+                toReturn.Add(new Tuple<string, string>(drug, ""));
+            }
+        }
+
+        return toReturn;
+    }
+
 }


### PR DESCRIPTION
horny, send zones

### Changes
1. Created Zones tab and added it to Player Information menu.
2. Display only zones from player’s current State
3. Display Gangs involved in said zone.
4. Display Drugs traded in said zone
	- Gang Products
	- Zone's Established Drug Menus
### Planned Updates
- Create basic Zone Reputation
	- Add interaction tab to zones similar to gang tab, but it details the amount of civilians killed
	- Taking inspiration from [Watch Dogs reputation system](https://watchdogs.fandom.com/wiki/Reputation)