### PR TITLE
Bug Fix, Small QoL change and Naming Change

### DIFF
--- a/Los Santos RED/lsr/Data/Items/CraftableItems.cs
+++ b/Los Santos RED/lsr/Data/Items/CraftableItems.cs
@@ -64,7 +64,7 @@ public class CraftableItems : ICraftableItems
                 Category = "Narcotics",
             },
             
-            new CraftableItem("Cut Cocaine", "Crack", 
+            new CraftableItem("Cook Crack", "Crack", 
             new List<Ingredient>() 
             {
                 new Ingredient() { IngredientName =  "Cocaine", Quantity = 1},

--- a/Los Santos RED/lsr/Locations/Places/GameLocations/ExteriorCraftingLocation.cs
+++ b/Los Santos RED/lsr/Locations/Places/GameLocations/ExteriorCraftingLocation.cs
@@ -13,7 +13,7 @@ public class ExteriorCraftingLocation : GameLocation
     {
 
     }
-    public override string TypeName { get; set; } = "CraftingLocation";
+    public override string TypeName { get; set; } = "Crafting Location";
     public override int MapIcon { get; set; } = 537;//873;//162;
     public string CraftingFlag { get; set; }
     public override bool CanCurrentlyInteract(ILocationInteractable player)

--- a/Los Santos RED/lsr/Player/Inventory/Items/CraftableItem.cs
+++ b/Los Santos RED/lsr/Player/Inventory/Items/CraftableItem.cs
@@ -46,6 +46,10 @@ public class CraftableItem
         StringBuilder ingredientStringBuilder = new StringBuilder();
         foreach (var ingredient in Ingredients)
         {
+            if (!ingredient.IsConsumed)
+            {
+                quantity = 1;
+            }
             ingredientStringBuilder.Append($"X{ingredient.Quantity * quantity} {ingredient.IngredientName}\n");
         }
         return ingredientStringBuilder.ToString().Trim();

--- a/Los Santos RED/lsr/UI/Menu/Main/CraftingMenu.cs
+++ b/Los Santos RED/lsr/UI/Menu/Main/CraftingMenu.cs
@@ -90,6 +90,10 @@ public class CraftingMenu : ModUIMenu
         }
         foreach(CraftableItem craftableItem in CraftableItems.Items)
         {
+            if (!string.IsNullOrEmpty(craftingFlag) && craftableItem.CraftingFlags != null && !craftableItem.CraftingFlags.Contains(craftingFlag))
+            {
+                continue;
+            }
             if (craftableItem.CraftingFlags != null && craftableItem.CraftingFlags.Count > 0 && !craftableItem.CraftingFlags.Contains(craftingFlag))
             {
                 continue;
@@ -112,7 +116,10 @@ public class CraftingMenu : ModUIMenu
                 }
                 else
                 {
-                    quantity = quantity == 0 ? instancesCraftable : Math.Min(quantity, instancesCraftable);
+                    if (ingredient.IsConsumed)
+                    {
+                        quantity = quantity == 0 ? instancesCraftable : Math.Min(quantity, instancesCraftable);
+                    }
                     ingredientsSatisfied++;
                 }
             }


### PR DESCRIPTION
1. Los Santos RED/lsr/Locations/Places/GameLocations/ExteriorCraftingLocation.cs

- "Crafting Location" instead of "CraftingLocation" for GPS and visual reasons.

2. Los Santos RED/lsr/Player/Inventory/Items/CraftableItem.cs

- Description to show in crafting menu does not increase the quantity of items that aren't consumed based on ResultantAmount.

3. Los Santos RED/lsr/UI/Menu/Main/CraftingMenu.cs

- Crafting at a location only shows you things you can craft with that flag instead of including items craftable without the flag.

- Bug with requiring (quantity x required amount) even for non-consumed items in a recipe.

Thanks to @aleur for pointing out bugs.