### PR TITLE
Bug fix - properties, residences and businesses.

### DIFF
--- a/Los Santos RED/lsr/Data/Saves/GameSave.cs
+++ b/Los Santos RED/lsr/Data/Saves/GameSave.cs
@@ -339,7 +339,7 @@ namespace LosSantosRED.lsr.Data
                 if (res.IsOwned || res.IsRented)
                 {
                     SavedResidence myRes = new SavedResidence(res.Name, res.IsOwned, res.IsRented);
-                    if (res.IsRented)
+                    if (res.IsRented || res.IsRentedOut)
                     {
                         myRes.DateOfLastRentalPayment = res.DateRentalPaymentPaid;
                         myRes.RentalPaymentDate = res.DateRentalPaymentDue;

--- a/Los Santos RED/lsr/Locations/Places/GameLocation.cs
+++ b/Los Santos RED/lsr/Locations/Places/GameLocation.cs
@@ -1384,6 +1384,8 @@ public class GameLocation : ILocationDispatchable
     public virtual void Payout(IPropertyOwnable player, ITimeReportable time)
     {
         int numberOfPaymentsToProcess = (time.CurrentDateTime - DatePayoutPaid).Days;
+        DatePayoutPaid = time.CurrentDateTime;
+        DatePayoutDue = DatePayoutPaid.AddDays(PayoutFrequency);
         int payoutAmount = CalculatePayoutAmount(numberOfPaymentsToProcess);
         player.BankAccounts.GiveMoney(payoutAmount, true);
     }

--- a/Los Santos RED/lsr/Player/Money/Properties.cs
+++ b/Los Santos RED/lsr/Player/Money/Properties.cs
@@ -83,7 +83,7 @@ public class Properties
     }
     public void RemoveResidence(Residence toAdd)
     {
-        if (!Residences.Any(x => x.Name == toAdd.Name))
+        if (Residences.Any(x => x.Name == toAdd.Name))
         {
             toAdd.Reset();
             Residences.Remove(toAdd);
@@ -98,7 +98,7 @@ public class Properties
     }
     public void RemovePayoutProperty(GameLocation toRemove)
     {
-        if (!PayoutProperties.Any(x => x.Name == toRemove.Name && x.EntrancePosition == toRemove.EntrancePosition))
+        if (PayoutProperties.Any(x => x.Name == toRemove.Name && x.EntrancePosition == toRemove.EntrancePosition))
         {
             toRemove.Reset();
             PayoutProperties.Remove(toRemove);
@@ -113,7 +113,7 @@ public class Properties
     }
     public void RemoveBusiness(Business toRemove)
     {
-        if (!Businesses.Any(x => x.Name == toRemove.Name && x.EntrancePosition == toRemove.EntrancePosition))
+        if (Businesses.Any(x => x.Name == toRemove.Name && x.EntrancePosition == toRemove.EntrancePosition))
         {
             toRemove.Reset();
             Businesses.Remove(toRemove);

--- a/Los Santos RED/lsr/UI/Menu/Main/CraftingMenu.cs
+++ b/Los Santos RED/lsr/UI/Menu/Main/CraftingMenu.cs
@@ -125,6 +125,10 @@ public class CraftingMenu : ModUIMenu
             }
             if (ingredientsSatisfied != ingredientsToSatisfy || quantity==0)
             {
+                UIMenu uIMenu = GetSubMenuForCraftableItem(craftableItem.Category, categoryMenus);
+                UIMenuItem itemMenu = new UIMenuItem(craftableItem.Name, craftableItem.IngredientList);
+                itemMenu.Enabled = false;
+                uIMenu.AddItem(itemMenu);
                 continue;
             }
             if (quantity > 0)


### PR DESCRIPTION
Pre-existing bug with residences too - check line change at 86 of Properties.cs.

https://github.com/thatoneguy650/Los-Santos-RED/blob/master/Los%20Santos%20RED/lsr/Data/Saves/GameSave.cs#L339- this line prevented it from being a bug (the list still contained the house in residence in-memory) before since buildings didn't pay out anything. But with businesses and rentable houses now paying out money I think this is an issue.