### PR TITLE
Fix for Issue #92

### DIFF
--- a/Los Santos RED/lsr/Player/Money/BankAccounts.cs
+++ b/Los Santos RED/lsr/Player/Money/BankAccounts.cs
@@ -171,8 +171,8 @@ public class BankAccounts
                 EntryPoint.WriteToConsole($"GiveMoneyAccount BEGIN {ba.BankContactName} {ba.Money}");
                 if (AccountMoneyTakenAlready + ba.Money < 0)
                 {
-                    ba.Money = 0;
                     AccountMoneyTakenAlready += ba.Money;
+                    ba.Money = 0;
                 }
                 else
                 {


### PR DESCRIPTION
Cause: Value assignment of bank balance to 0 before subtracting.